### PR TITLE
修正：文件后缀包含正则判断

### DIFF
--- a/front-end/index.html
+++ b/front-end/index.html
@@ -797,7 +797,7 @@
                                 const object = this;
                                 for (const key in object) {
                                     if (object.hasOwnProperty(key)) {
-                                        if ((eval('/' + search + '/i')).test(object[key])) {
+                                        if ((eval('/^' + search + '$/i')).test(object[key])) {
                                             return true;
                                         }
                                     }


### PR DESCRIPTION
当我添加一个`xxx.c`文件时，它无法正确判断文件后缀，会返回一个`audio`，具体原因是正则判断问题，应该从头到尾这个后缀都要匹配上才算包含。