### PR TITLE
fix: Block malicious upload attempts

### DIFF
--- a/back-end-cf/index.js
+++ b/back-end-cf/index.js
@@ -52,7 +52,7 @@ async function handleRequest(request) {
   const file = requestUrl.searchParams.get('file') || (requestUrl.pathname.split('/').filter(Boolean).length === 0 ? '' : decodeURIComponent(requestUrl.pathname));
   if (file) {
     const fileName = file.split('/').pop();
-    if (fileName.toLowerCase() === PASSWD_FILENAME.toLowerCase() || fileName.toLowerCase() === '.upload')
+    if (fileName.toLowerCase() === PASSWD_FILENAME.toLowerCase())
       return Response.redirect(
         'https://www.baidu.com/s?wd=%E6%80%8E%E6%A0%B7%E7%9B%97%E5%8F%96%E5%AF%86%E7%A0%81',
         301
@@ -63,15 +63,14 @@ async function handleRequest(request) {
   } else if (requestUrl.searchParams.get('upload')) {
     requestPath = requestUrl.searchParams.get('upload');
     const upload = await fetchFiles(requestPath, '.upload');
-    const uploadSecret = upload ? (await getContent(upload) || 'webupload') : '';
+    const uploadSecret = await fetchFiles(requestPath, PASSWD_FILENAME, null, true) || '';
     const fileList = await request.json();
     const uploadAttack = fileList['files'].some(
       (file) =>
         file.remotePath.split('/').pop().toLowerCase() ===
-        PASSWD_FILENAME.toLowerCase() ||
-        file.remotePath.split('/').pop().toLowerCase() === '.upload'
+        PASSWD_FILENAME.toLowerCase()
     ) || fileList['secret'] !== uploadSecret;
-    if (!uploadAttack) {
+    if (upload && !uploadAttack) {
       const uploadLinks = await uploadFiles(fileList);
       return new Response(uploadLinks, {
         headers: returnHeaders,

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -1716,7 +1716,7 @@
           sendRequest(
             window.api.method,
             window.api.url + '?upload=' + odPath,
-            JSON.stringify({ files: currentPage }),
+            JSON.stringify({ secret: 'webupload', files: currentPage }),
             window.api.headers,
             (response) => {
               const uploadLinks = JSON.parse(response).files;

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -1077,6 +1077,7 @@
                 input.placeholder = '密码错误';
               } else {
                 window.fileCache.set(newFiles.parent, newFiles);
+                window.fileCache.set(`${newFiles.parent}/.upload`, passwd);
                 fetchFileList(newFiles.parent);
               }
             }
@@ -1716,7 +1717,7 @@
           sendRequest(
             window.api.method,
             window.api.url + '?upload=' + odPath,
-            JSON.stringify({ secret: 'webupload', files: currentPage }),
+            JSON.stringify({ secret: window.fileCache.get(`${odPath}/.upload`) || '', files: currentPage }),
             window.api.headers,
             (response) => {
               const uploadLinks = JSON.parse(response).files;


### PR DESCRIPTION
之前的上传模式可以通过直接请求是否有 `.upload` 文件进行暴力上传，目前加了个 secret 验证，这就让新建的上传验证文件必须为空或者内容必须为 `webupload` ，否则将禁止上传。目前还需要解决将 `.upload` 传到前端， secret 就会泄露的问题。