### PR TITLE
support for files pagnation, remove python backend

### DIFF
--- a/back-end-cf/index.js
+++ b/back-end-cf/index.js
@@ -95,7 +95,7 @@ async function handleRequest(request) {
   }
 
   // List a folder
-  const files = await fetchFiles(requestPath, body.passwd, body.skipToken);
+  const files = await fetchFiles(requestPath, body.passwd, body.skipToken, body.orderby);
   return new Response(files, {
     headers: returnHeaders,
   });
@@ -188,7 +188,7 @@ async function authenticate(path, passwd) {
   }
 }
 
-async function fetchFiles(path, passwd, skipToken, order) {
+async function fetchFiles(path, passwd, skipToken, orderby) {
   const parent = path || '/';
   try {
     await authenticate(path, passwd);
@@ -207,7 +207,7 @@ async function fetchFiles(path, passwd, skipToken, order) {
   const accessToken = await fetchAccessToken();
   const expand = ':/children' +
     '?select=name,size,parentReference,lastModifiedDateTime,@microsoft.graph.downloadUrl' +
-    `&$top=50${order ? '&$orderby=' + order : ''}` +
+    `&$top=50${orderby ? '&$orderby=' + orderby : ''}` +
     (skipToken ? '&skiptoken=' + skipToken : '');
   const uri = OAUTH.apiUrl + path + expand;
 
@@ -224,6 +224,7 @@ async function fetchFiles(path, passwd, skipToken, order) {
   return JSON.stringify({
     parent,
     skipToken,
+    orderby,
     files: children
       .map((file) => ({
         name: file.name,

--- a/back-end-cf/index.js
+++ b/back-end-cf/index.js
@@ -95,7 +95,7 @@ async function handleRequest(request) {
   }
 
   // List a folder
-  const files = await fetchFiles(requestPath, body.passwd);
+  const files = await fetchFiles(requestPath, body.passwd, body.skipToken);
   return new Response(files, {
     headers: returnHeaders,
   });
@@ -188,7 +188,7 @@ async function authenticate(path, passwd) {
   }
 }
 
-async function fetchFiles(path, passwd) {
+async function fetchFiles(path, passwd, skipToken, order) {
   const parent = path || '/';
   try {
     await authenticate(path, passwd);
@@ -202,30 +202,28 @@ async function fetchFiles(path, passwd) {
 
   if (path === '/') path = '';
   if (path || EXPOSE_PATH)
-    path = ':' + encodeURIComponent(EXPOSE_PATH + path) + ':';
+    path = ':' + encodeURIComponent(EXPOSE_PATH + path);
 
   const accessToken = await fetchAccessToken();
-  const expand =
-    '/children?select=name,size,parentReference,lastModifiedDateTime,@microsoft.graph.downloadUrl&$top=200';
+  const expand = ':/children' +
+    '?select=name,size,parentReference,lastModifiedDateTime,@microsoft.graph.downloadUrl' +
+    `&$top=50${order ? '&$orderby=' + order : ''}` +
+    (skipToken ? '&skiptoken=' + skipToken : '');
   const uri = OAUTH.apiUrl + path + expand;
 
-  let pageRes = await getContent(uri, {
+  const pageRes = await getContent(uri, {
     Authorization: 'Bearer ' + accessToken,
   });
   if (pageRes.error) {
     throw new Error('request failed');
   }
-
-  let children = pageRes.value;
-  while (pageRes['@odata.nextLink']) {
-    pageRes = await getContent(pageRes['@odata.nextLink'], {
-      Authorization: 'Bearer ' + accessToken,
-    });
-    children = children.concat(pageRes.value);
-  }
+  
+  skipToken = pageRes['@odata.nextLink'] ? new URL(pageRes['@odata.nextLink']).searchParams.get('$skiptoken') : '';
+  const children = pageRes.value;
 
   return JSON.stringify({
     parent,
+    skipToken,
     files: children
       .map((file) => ({
         name: file.name,
@@ -244,9 +242,9 @@ async function downloadFile(filePath, format, stream) {
   }
 
   filePath = encodeURIComponent(`${EXPOSE_PATH}${filePath}`);
-  const uri =
-    `${OAUTH.apiUrl}:${filePath}:/content` +
-    (format ? `?format=${format}` : '');
+  const uri = `${OAUTH.apiUrl}:${filePath}:/content` +
+    (format ? `?format=${format}` : '') + 
+    (format === 'jpg' ? '&width=30000&height=30000' : '');
   const accessToken = await fetchAccessToken();
 
   return cacheFetch(uri, {

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -1656,7 +1656,9 @@
       }
 
       function sortList(clickedElem) {
-        let loadedPages = window.fileCache.get(window.backFordwardCache.current);
+        let loadedPages = window.fileCache.get(
+          window.backFordwardCache.current
+        );
         const oldSortOrder = loadedPages?.orderby || 'name asc';
         const sortField = clickedElem.className;
         const sortOrder = oldSortOrder.split(' ')[1] === 'asc' ? 'desc' : 'asc';
@@ -1666,13 +1668,18 @@
         }
         if (loadedPages.skipToken) {
           window.fileCache.set(window.backFordwardCache.current, false);
-          fetchFileList(window.backFordwardCache.current, newSortOrder.replace('time', 'lastModifiedDateTime'));
-        } else{
+          fetchFileList(
+            window.backFordwardCache.current,
+            newSortOrder.replace('time', 'lastModifiedDateTime')
+          );
+        } else {
           alert(newSortOrder);
           loadedPages.orderby = newSortOrder;
           loadedPages.files.sort((a, b) => {
-            if (a[sortField] < b[sortField]) return sortOrder === 'asc' ? -1 : 1;
-            if (a[sortField] > b[sortField]) return sortOrder === 'asc' ? 1 : -1;
+            if (a[sortField] < b[sortField])
+              return sortOrder === 'asc' ? -1 : 1;
+            if (a[sortField] > b[sortField])
+              return sortOrder === 'asc' ? 1 : -1;
             return 0;
           });
           renderPage(loadedPages);
@@ -1925,12 +1932,14 @@
         addFileUploadListener();
         const rightDiv = document.querySelector('div.right');
         let isRequestInProgress = false;
-        rightDiv.addEventListener('scroll', function() {
+        rightDiv.addEventListener('scroll', function () {
           const scrollPosition = rightDiv.scrollTop + rightDiv.clientHeight;
           const scrollHeight = rightDiv.scrollHeight;
-          let loadedPages = window.fileCache.get(window.backFordwardCache.current);
+          let loadedPages = window.fileCache.get(
+            window.backFordwardCache.current
+          );
           if (scrollPosition >= scrollHeight - 20 && loadedPages.skipToken) {
-            if(isRequestInProgress) return;
+            if (isRequestInProgress) return;
             isRequestInProgress = true;
             sendRequest(
               window.api.method,
@@ -1938,14 +1947,20 @@
               window.api.formatPayload(
                 loadedPages.parent,
                 window.fileCache.get(`${loadedPages.parent}/.password`),
-                { skipToken: loadedPages.skipToken, orderby: loadedPages.orderby }
+                {
+                  skipToken: loadedPages.skipToken,
+                  orderby: loadedPages.orderby,
+                }
               ),
               window.api.headers,
               (data) => {
                 data = JSON.parse(data);
                 loadedPages.files = loadedPages.files.concat(data.files);
                 loadedPages.skipToken = data.skipToken;
-                window.fileCache.set(window.backFordwardCache.current, loadedPages);
+                window.fileCache.set(
+                  window.backFordwardCache.current,
+                  loadedPages
+                );
                 renderPage(loadedPages);
                 isRequestInProgress = false;
               },

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -1656,7 +1656,7 @@
       }
 
       function sortList(clickedElem) {
-        let loadedPages = window.fileCache.get(
+        const loadedPages = window.fileCache.get(
           window.backFordwardCache.current
         );
         const oldSortOrder = loadedPages?.orderby || 'name asc';

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -5,8 +5,7 @@
       window.GLOBAL_CONFIG = {
         SCF_GATEWAY: `//tight-bar-e3b3.logi.workers.dev`, // Worker 或云函数网关地址
         SITE_NAME: `FODI`, // 站点名称
-        PRELOAD: false,
-        IS_CF: true,
+        PRELOAD: false, // 是否预加载文件列表
       };
     </script>
     <meta charset="utf-8" />
@@ -719,7 +718,7 @@
       function renderPage(data, cache) {
         let files;
         if (data) {
-          files = JSON.parse(data);
+          files = typeof data === 'string' ? JSON.parse(data) : data;
           window.fileCache.set(files.parent, files);
           preCache(files, 0);
         } else {
@@ -1074,7 +1073,7 @@
                 input.placeholder = '密码错误';
               } else {
                 window.fileCache.set(newFiles.parent, newFiles);
-                window.fileCache.set(`${newFiles.parent}/.upload`, passwd);
+                window.fileCache.set(`${newFiles.parent}/.password`, passwd);
                 fetchFileList(newFiles.parent);
               }
             }
@@ -1724,7 +1723,7 @@
             window.api.url + '?upload',
             window.api.formatPayload(
               odPath,
-              window.fileCache.get(`${odPath}/.upload`) || '',
+              window.fileCache.get(`${odPath}/.password`),
               {
                 files: currentPage,
               }
@@ -1878,7 +1877,6 @@
             JSON.stringify({
               path,
               passwd,
-              ...window.api.accessToken,
               ...kvs,
             }),
           headers: {
@@ -1898,28 +1896,42 @@
         const initialPath =
           new URLSearchParams(window.location.search).get('path') ||
           window.api.root;
-        if (window.GLOBAL_CONFIG.IS_CF) {
-          fetchFileList(initialPath);
-          addBackForwardListener();
-          addFileUploadListener();
-        } else {
-          sendRequest(
-            window.api.method,
-            window.api.url + '?accessToken',
-            null,
-            window.api.headers,
-            (data) => {
-              const accessToken = JSON.parse(data);
-              window.api.accessToken = {
-                encrypted: accessToken.encrypted,
-                plain: accessToken.plain,
-              };
-              fetchFileList(initialPath);
-              addBackForwardListener();
-              addFileUploadListener();
-            }
-          );
-        }
+        fetchFileList(initialPath);
+        addBackForwardListener();
+        addFileUploadListener();
+        const rightDiv = document.querySelector('div.right');
+        rightDiv.addEventListener('scroll', function() {
+          const scrollPosition = rightDiv.scrollTop + rightDiv.clientHeight;
+          const scrollHeight = rightDiv.scrollHeight;
+          let loadedPages = window.fileCache.get(window.backFordwardCache.current);
+          let isRequestInProgress = false;
+          if (scrollPosition >= scrollHeight && loadedPages.skipToken) {
+            if(isRequestInProgress) return;
+            isRequestInProgress = true;
+            sendRequest(
+              window.api.method,
+              window.api.url,
+              window.api.formatPayload(
+                loadedPages.parent,
+                window.fileCache.get(`${loadedPages.parent}/.password`),
+                { skipToken: loadedPages.skipToken }
+              ),
+              window.api.headers,
+              (data) => {
+                data = JSON.parse(data);
+                loadedPages.files = loadedPages.files.concat(data.files);
+                loadedPages.skipToken = data.skipToken;
+                window.fileCache.set(window.backFordwardCache.current, loadedPages);
+                renderPage(loadedPages);
+                isRequestInProgress = false;
+              },
+              () => {
+                const loadingText = loading.querySelector('.loading');
+                loadingText.innerText = 'Loading NextPage Failed!';
+              }
+            );
+          }
+        });
       });
     </script>
   </head>

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -1655,7 +1655,31 @@
         });
       }
 
-      function fetchFileList(path) {
+      function sortList(clickedElem) {
+        let loadedPages = window.fileCache.get(window.backFordwardCache.current);
+        const oldSortOrder = loadedPages?.orderby || 'name asc';
+        const sortField = clickedElem.className;
+        const sortOrder = oldSortOrder.split(' ')[1] === 'asc' ? 'desc' : 'asc';
+        const newSortOrder = `${sortField} ${sortOrder}`;
+        if (oldSortOrder === newSortOrder) {
+          return;
+        }
+        if (loadedPages.skipToken) {
+          window.fileCache.set(window.backFordwardCache.current, false);
+          fetchFileList(window.backFordwardCache.current, newSortOrder.replace('time', 'lastModifiedDateTime'));
+        } else{
+          alert(newSortOrder);
+          loadedPages.orderby = newSortOrder;
+          loadedPages.files.sort((a, b) => {
+            if (a[sortField] < b[sortField]) return sortOrder === 'asc' ? -1 : 1;
+            if (a[sortField] > b[sortField]) return sortOrder === 'asc' ? 1 : -1;
+            return 0;
+          });
+          renderPage(loadedPages);
+        }
+      }
+
+      function fetchFileList(path, orderby) {
         // console.log('fetching ' + path);
         const loading = document.querySelector('.loading-wrapper');
         loading.dataset.hidden = '0';
@@ -1673,7 +1697,7 @@
           sendRequest(
             window.api.method,
             window.api.url,
-            window.api.formatPayload(path),
+            window.api.formatPayload(path, '', { orderby: orderby }),
             window.api.headers,
             renderPage,
             () => {
@@ -1900,12 +1924,12 @@
         addBackForwardListener();
         addFileUploadListener();
         const rightDiv = document.querySelector('div.right');
+        let isRequestInProgress = false;
         rightDiv.addEventListener('scroll', function() {
           const scrollPosition = rightDiv.scrollTop + rightDiv.clientHeight;
           const scrollHeight = rightDiv.scrollHeight;
           let loadedPages = window.fileCache.get(window.backFordwardCache.current);
-          let isRequestInProgress = false;
-          if (scrollPosition >= scrollHeight && loadedPages.skipToken) {
+          if (scrollPosition >= scrollHeight - 20 && loadedPages.skipToken) {
             if(isRequestInProgress) return;
             isRequestInProgress = true;
             sendRequest(
@@ -1914,7 +1938,7 @@
               window.api.formatPayload(
                 loadedPages.parent,
                 window.fileCache.get(`${loadedPages.parent}/.password`),
-                { skipToken: loadedPages.skipToken }
+                { skipToken: loadedPages.skipToken, orderby: loadedPages.orderby }
               ),
               window.api.headers,
               (data) => {
@@ -1928,6 +1952,7 @@
               () => {
                 const loadingText = loading.querySelector('.loading');
                 loadingText.innerText = 'Loading NextPage Failed!';
+                isRequestInProgress = false;
               }
             );
           }
@@ -1994,9 +2019,9 @@
           <div class="list-header">
             <div class="row">
               <div class="file">
-                <span class="name">ITEMS</span>
-                <span class="time">TIME</span>
-                <span class="size">SIZE</span>
+                <span class="name" onclick="sortList(this)">ITEMS</span>
+                <span class="time" onclick="sortList(this)">TIME</span>
+                <span class="size" onclick="sortList(this)">SIZE</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
支持文件分页，移除了对于 python 后端的支持。
1. 但是 `scrollPosition >= scrollHeight` 的条件在不同的设备可能不一定会生效，手机上一定是生效的，如果改成 `scrollPosition >= scrollHeight - 20` 又不灵敏触发多次请求，你看看是哪里样式的问题。
2. 后端是支持排序请求了，前端如果没有 skiptoken 可以直接前端排序，如果有的话不然需要重新请求不然就干脆别排序了。